### PR TITLE
Vectorize chi calculation

### DIFF
--- a/legume/gme/gme.py
+++ b/legume/gme/gme.py
@@ -339,14 +339,9 @@ class GuidedModeExp(object):
         vectors gk and frequencies oms (can be either a single number or an 
         array of the same shape as gk)
         """
-        chis = []
-        for il in range(self.N_layers + 2):
-            sqarg = bd.array(eps_array[il] * bd.square(oms) - bd.square(gk),
-                             dtype=bd.complex)
-            chi = bd.where(
-                bd.real(sqarg) >= 0, bd.sqrt(sqarg), 1j * bd.sqrt(-sqarg))
-            chis.append(chi)
-        return bd.array(chis, dtype=bd.complex)
+        sqarg = eps_array[:, None]*bd.square(oms) - bd.square(gk)
+        return bd.where(
+            bd.real(sqarg) >= 0, bd.sqrt(sqarg), 1j * bd.sqrt(-sqarg))
 
     def _get_rad(self, gkr, omr, pol, clad):
         """


### PR DESCRIPTION
## Summary
- Vectorized chi calculation by removing per-layer loop in `_get_chi`
- Applied `bd.where`/`bd.sqrt` directly to broadcasted arrays

## Testing
- `pip install -r requirements.txt pytest` *(fails: Could not connect to proxy)*
- `pytest -q` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b609b20fbc83238a7f664de19266e8